### PR TITLE
vimc-4258 move to buildkite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
 FROM openjdk:8
 
-ARG libsodium_version='1.0.18'
-
 RUN apt-get update
 RUN apt-get install -y build-essential
 
-RUN mkdir /build && \
-        curl "https://download.libsodium.org/libsodium/releases/libsodium-${libsodium_version}.tar.gz" | \
-                tar xz --directory /build && \
-        cd /build/libsodium-${libsodium_version} && \
-        ./configure && \
-        make all check install && \
-        rm -rf /build
+COPY . .
+RUN ./install-libsodium.sh

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # openjdk-libsodium
-Contains a docker file for an image based on `openjdk` with `libsodium` installed, and script to build, tag and push
-the image to the vimc registry.
+Contains a script for installing [libsodium](https://libsodium.gitbook.io/doc/),
+ a docker file for an image based on `openjdk` with `libsodium`
+ installed, and a script to build, tag and push the image to docker hub.
 
 ## building
-Run `./build-image.sh` to build and push to the vimc registry. This script is also run on Teamcity.
+Run `./build-image.sh` to build and push to docker hub. This script is also run on Buildkite.
 
 ## usage
-This image is used by [Montagu-Api](https://github.com/vimc/montagu-api-Api) 
-and [Kodiak](https://github.com/vimc/kodiak).
+* The image `vimc/openjdk-libsodium:master` is used as a base image for various images 
+built by [Montagu-API](https://github.com/vimc/montagu-api).
+ 
+* To install libsodium locally: `sudo ./install-libsodium.sh`. In particular this is needed for local development 
+of [Montagu-API](https://github.com/vimc/montagu-api).

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-GIT_ID=$(git rev-parse --short=7 HEAD)
-GIT_BRANCH=$(git symbolic-ref --short HEAD)
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_ID=${BUILDKITE_COMMIT:0:7}
+else
+    GIT_ID=$(git rev-parse --short=7 HEAD)
+fi
+
+if [ "$BUILDKITE" = "true" ]; then
+    GIT_BRANCH=$BUILDKITE_BRANCH
+else
+    GIT_BRANCH=$(git symbolic-ref --short HEAD)
+fi
 ORG=vimc
 NAME=openjdk-libsodium
 

--- a/build-image.sh
+++ b/build-image.sh
@@ -3,16 +3,14 @@ set -e
 
 GIT_ID=$(git rev-parse --short=7 HEAD)
 GIT_BRANCH=$(git symbolic-ref --short HEAD)
-REGISTRY=docker.montagu.dide.ic.ac.uk:5000
+ORG=vimc
 NAME=openjdk-libsodium
-LIBSODIUM_VERSION=$(<libsodium-version)
 
-APP_DOCKER_TAG=${REGISTRY}/${NAME}
-APP_DOCKER_COMMIT_TAG=${REGISTRY}/${NAME}:${GIT_ID}
-APP_DOCKER_BRANCH_TAG=${REGISTRY}/${NAME}:${GIT_BRANCH}
+APP_DOCKER_TAG=${ORG}/${NAME}
+APP_DOCKER_COMMIT_TAG=${ORG}/${NAME}:${GIT_ID}
+APP_DOCKER_BRANCH_TAG=${ORG}/${NAME}:${GIT_BRANCH}
 
 docker build \
-    --build-arg libsodium_version=${LIBSODIUM_VERSION} \
     --pull \
     --tag ${APP_DOCKER_BRANCH_TAG} \
     --tag ${APP_DOCKER_COMMIT_TAG} \

--- a/buildkite/pipeline.yml
+++ b/buildkite/pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: ":shipit: Build and push image"
+    command: ./build-image.sh

--- a/install-libsodium.sh
+++ b/install-libsodium.sh
@@ -1,19 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
-mkdir -p lib
-here=$(dirname $0)
-config_path=$(realpath ./$here/libsodium-version)
-libsodium_version=$(<$config_path)
+HERE=$(dirname $0)
+CONFIG_PATH=$(realpath ./$HERE/libsodium-version)
+LIBSODIUM_VERSION=$(<$CONFIG_PATH)
 
-curl https://download.libsodium.org/libsodium/releases/libsodium-${libsodium_version}.tar.gz \
-    | tar xz --directory lib/
-
-cd lib/libsodium-${libsodium_version}/
-
-./configure
-make
-make check
-make install
-
-cd -
+mkdir /build &&
+  curl "https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz" |
+  tar xz --directory /build --strip 1 &&
+  cd /build &&
+  ./configure &&
+  make all check install &&
+  rm -rf /build


### PR DESCRIPTION
As well as adding a buildkite pipeline, I've removed the old reference to the private docker registry, updated the README, and tidied up the code so that logic is re-used between the script `install-libsodium.sh` and the docker container itself. 