### PR TITLE
vimc-6446 build java 8 and java 11 images with different tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8
+ARG OPEN_JDK_BASE=openjdk:8
+FROM $OPEN_JDK_BASE
 
 RUN apt-get update
 RUN apt-get install -y build-essential

--- a/build-image.sh
+++ b/build-image.sh
@@ -15,12 +15,24 @@ fi
 ORG=vimc
 NAME=openjdk-libsodium
 
-APP_DOCKER_TAG=${ORG}/${NAME}
-APP_DOCKER_COMMIT_TAG=${ORG}/${NAME}:${GIT_ID}
-APP_DOCKER_BRANCH_TAG=${ORG}/${NAME}:${GIT_BRANCH}
+APP_DOCKER_COMMIT_TAG=${ORG}/${NAME}:${GIT_ID}-8
+APP_DOCKER_BRANCH_TAG=${ORG}/${NAME}:${GIT_BRANCH}-8
 
 docker build \
     --pull \
+    --tag ${APP_DOCKER_BRANCH_TAG} \
+    --tag ${APP_DOCKER_COMMIT_TAG} \
+    .
+
+docker push ${APP_DOCKER_BRANCH_TAG}
+docker push ${APP_DOCKER_COMMIT_TAG}
+
+APP_DOCKER_COMMIT_TAG=${ORG}/${NAME}:${GIT_ID}-11
+APP_DOCKER_BRANCH_TAG=${ORG}/${NAME}:${GIT_BRANCH}-11
+
+docker build \
+    --pull \
+    --build-arg OPEN_JDK_BASE=openjdk:11 \
     --tag ${APP_DOCKER_BRANCH_TAG} \
     --tag ${APP_DOCKER_COMMIT_TAG} \
     .


### PR DESCRIPTION
I've gone with just building two sets on images with the java version appended to the tag, although possibly we can deprecate the java 8 one entirely.